### PR TITLE
do-not-merge

### DIFF
--- a/source/goodsoup/amiga/audio_hook.c
+++ b/source/goodsoup/amiga/audio_hook.c
@@ -1,5 +1,5 @@
 #include <proto/exec.h>
-#include "amiga/sdi/sdi_hook.h"
+#include "amiga/SDI/SDI_hook.h"
 
 struct AHIAudioCtrl;
 struct AHISoundMessage;

--- a/source/goodsoup/endian.h
+++ b/source/goodsoup/endian.h
@@ -126,11 +126,11 @@ namespace gs
 		*(uint32 *)(ptr) = value;
 	}
 
-	inline uint16 READ_BE_INT16(const void *ptr) {
-		return *(const uint16 *)(ptr);
+	inline int16 READ_BE_INT16(const void *ptr) {
+		return *(const int16 *)(ptr);
 	}
-	inline uint32 READ_BE_INT32(const void *ptr) {
-		return *(const uint32 *)(ptr);
+	inline int32 READ_BE_INT32(const void *ptr) {
+		return *(const int32 *)(ptr);
 	}
 	inline void WRITE_BE_INT16(void *ptr, int16 value) {
 		*(uint16 *)(ptr) = value;
@@ -174,17 +174,17 @@ inline uint16 READ_LE_UINT16(const void *ptr) {
 	inline void WRITE_LE_UINT32(void *ptr, uint32 value) {
 		*(uint32 *)(ptr) = value;
 	}
-	inline uint16 READ_LE_INT16(const void *ptr) {
-		return *(const uint16 *)(ptr);
+	inline int16 READ_LE_INT16(const void *ptr) {
+		return *(const int16 *)(ptr);
 	}
-	inline uint32 READ_LE_INT32(const void *ptr) {
-		return *(const uint32 *)(ptr);
+	inline int32 READ_LE_INT32(const void *ptr) {
+		return *(const int32 *)(ptr);
 	}
 	inline void WRITE_LE_INT16(void *ptr, int16 value) {
-		*(uint16 *)(ptr) = value;
+		*(int16 *)(ptr) = value;
 	}
 	inline void WRITE_LE_INT32(void *ptr, int32 value) {
-		*(uint32 *)(ptr) = value;
+		*(int32 *)(ptr) = value;
 	}
 	inline uint16 READ_BE_UINT16(const void *ptr) {
 		const byte *b = (const byte *)ptr;

--- a/source/goodsoup/makefile
+++ b/source/goodsoup/makefile
@@ -28,7 +28,7 @@ ifeq ($(PLATFORM), amiga)
 
 	CC		= m68k-amigaos-gcc
 	DELETE	= rm
-	CFLAGS	+= -Iamiga -DGS_AMIGA -DGS_BIG -noixemul -fno-exceptions -fno-rtti -fno-threadsafe-statics -m68020
+	CFLAGS	+= -Iamiga -DGS_AMIGA -DGS_BIG -noixemul -fpermissive -fno-exceptions -fno-rtti -fno-threadsafe-statics -m68020
 ifeq ($(RELEASE), 1)
 	CFLAGS	+= -O2 -fno-builtin -DGS_RELEASE=1 -DGS_DEBUG_LEVEL=4 -DGS_PROTECT_MEMORY=0 -s
 else

--- a/source/goodsoup/sdl/audio_sdl.cpp
+++ b/source/goodsoup/sdl/audio_sdl.cpp
@@ -85,6 +85,8 @@ namespace gs
 
 	bool openAudio() {
 
+        return false;
+
 		SDL_AudioSpec want, have;
 
 		SDL_memset(&want, 0, sizeof(want)); /* or SDL_zero(want) */

--- a/source/goodsoup/video/smush/smush_codec47_opt_none.cpp
+++ b/source/goodsoup/video/smush/smush_codec47_opt_none.cpp
@@ -144,8 +144,9 @@ namespace gs
 			int32 tmpPtr2 = tmpPtr;
 
 			while (len--) {
-				int16 m = READ_LE_INT16(smush_table_small + tmpPtr2);
-				*(dst + offset + m) = val;
+				uint16 m = READ_LE_UINT16(smush_table_small + tmpPtr2);
+				if (m >= 32768) m -= 32768;
+				*(dst + offset + (int16)m) = val;
 				tmpPtr2 += 2;
 			}
 
@@ -153,8 +154,9 @@ namespace gs
 			val = *src++;
 			tmpPtr2 = tmpPtr + 32;
 			while (len--) {
-				int16 m = READ_LE_INT16(smush_table_small + tmpPtr2);
-				*(dst + offset + m) = val;
+				uint16 m = READ_LE_UINT16(smush_table_small + tmpPtr2);
+				if (m >= 32768) m -= 32768;
+				*(dst + offset + (int16)m) = val;
 				tmpPtr2 += 2;
 			}
 
@@ -257,8 +259,9 @@ namespace gs
 			int32 tmpPtr2 = tmpPtr;
 
 			while (l--) {
-				int16 m = READ_LE_INT16(smush_table_big + tmpPtr2);
-				*(dst + offset + m) = val;
+				uint16 m = READ_LE_UINT16(smush_table_big + tmpPtr2);
+				if (m >= 32768) m -= 32768;
+				*(dst + offset + (int16)m) = val;
 				tmpPtr2 += 2;
 			}
 
@@ -266,8 +269,9 @@ namespace gs
 			val = *src++;
 			tmpPtr2 = tmpPtr + 128;
 			while (l--) {
-				int16 m = READ_LE_INT16(smush_table_big + tmpPtr2);
-				*(dst + offset + m) = val;
+				uint16 m = READ_LE_UINT16(smush_table_big + tmpPtr2);
+				if (m >= 32768) m -= 32768;
+				*(dst + offset + (int16)m) = val;
 				tmpPtr2 += 2;
 			}
 

--- a/source/goodsoup/video/smush/smush_codec47_opt_ulong.cpp
+++ b/source/goodsoup/video/smush/smush_codec47_opt_ulong.cpp
@@ -182,7 +182,8 @@ namespace gs
 			int32 tmpPtr2 = tmpPtr;
 
 			while(len--) {
-				int16 m = READ_LE_INT16(smush_table_small + tmpPtr2);
+				uint16 m = READ_LE_UINT16(smush_table_small + tmpPtr2);
+				if (m >= 32768) m -= 32768;
 				*(bDst + m) = val;
 				tmpPtr2 += 2;
 			}
@@ -191,7 +192,8 @@ namespace gs
 			val = *src++;
 			tmpPtr2 = tmpPtr + 32;
 			while(len--) {
-				int16 m = READ_LE_INT16(smush_table_small + tmpPtr2);
+				uint16 m = READ_LE_UINT16(smush_table_small + tmpPtr2);
+				if (m >= 32768) m -= 32768;
 				*(bDst + m) = val;
 				tmpPtr2 += 2;
 			}
@@ -281,7 +283,8 @@ namespace gs
 			int32 tmpPtr2 = tmpPtr;
 
 			while(l--) {
-				int16 m = READ_LE_INT16(smush_table_big + tmpPtr2);
+				uint16 m = READ_LE_UINT16(smush_table_big + tmpPtr2);
+				if (m >= 32768) m -= 32768;
 				*(bDst + m) = val;
 				tmpPtr2 += 2;
 			}
@@ -290,7 +293,8 @@ namespace gs
 			val = *src++;
 			tmpPtr2 = tmpPtr + 128;
 			while(l--) {
-				int16 m = READ_LE_INT16(smush_table_big + tmpPtr2);
+				uint16 m = READ_LE_UINT16(smush_table_big + tmpPtr2);
+				if (m >= 32768) m -= 32768;
 				*(bDst + m) = val;
 				tmpPtr2 += 2;
 			}

--- a/source/goodsoup/video/video_frame.cpp
+++ b/source/goodsoup/video/video_frame.cpp
@@ -340,6 +340,7 @@ namespace gs
 		AudioSampleFrame_S16MSB* sampleFrame = _audio.pullFront();
 
 		while(sampleFrame != NULL) {
+        /*
 			AudioSample_S16MSB *sample = audioStream->allocateSample();
 
 			sample->userMessage = getNum();
@@ -348,7 +349,7 @@ namespace gs
 			sample->pos = 0;
 			sample->remaining = 2048;
 			audioStream->pushSample(sample);
-
+        */
 			sampleFrame = _audio.pullFront();
 		}
 

--- a/source/goodsoup/vm/debugger.cpp
+++ b/source/goodsoup/vm/debugger.cpp
@@ -20,6 +20,7 @@
 #include "debugger.h"
 #include "vm.h"
 #include "../debug.h"
+#include "../string.h"
 
 #define GS_VM_DEBUG_COMMENTS 1
 #define GS_VM_DEBUG_SCRIPT 1


### PR DESCRIPTION
I just wrote this pull request to ask some questions.

So I run on Linux using SDL. I couldnt get the videos running using ./monkey 114 for example but changing this made it work (otherwise it would just crash because the value return could be negative).

When looking into the endian.c code, it was a bit confusing as well. I am not sure it actually works as it should. For instance the read in16 functions returns uint16 which is kinda strange. What do you think?